### PR TITLE
Optimize impl Partition for [T]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ name = "benchmark"
 harness = false
 
 
+[[bench]]
+name = "partition"
+harness = false
+
+
 [[example]]
 name = "extra_trees_regressor"
 path = "examples/extra_trees_regressor.rs"

--- a/benches/partition.rs
+++ b/benches/partition.rs
@@ -3,24 +3,41 @@ extern crate criterion;
 extern crate rand;
 extern crate forester;
 
-use std::f64;
-
 use criterion::Criterion;
 use criterion::Bencher;
 
 use forester::array_ops::Partition;
 
+fn safe_partition<T, F: FnMut(&T) -> bool>(x: &mut [T], mut predicate: F) -> usize {
+    let mut target_index = 0;
+    for i in 0..x.len() {
+        if predicate(&x[i]) {
+            x.swap(target_index, i);
+            target_index += 1;
+        }
+    }
+    target_index
+}
+
 
 fn bench_partition(c: &mut Criterion) {
-    fn function(b: &mut Bencher) {
-        let mut x: Vec<_> = (1..1000).collect();
+    fn function1(b: &mut Bencher) {
+        let x: Vec<_> = (1..1000).collect();
         b.iter(|| {
             x.clone().partition(|&i| i % 2 == 0);
         })
     }
+    c.bench_function("Partition (unsafe)", function1);
 
-    c.bench_function("Partition", function);
+
+    fn function2(b: &mut Bencher) {
+        let x: Vec<_> = (1..1000).collect();
+        b.iter(|| {
+            safe_partition(&mut x.clone(), |&i| i % 2 == 0);
+        })
+    }
+    c.bench_function("Partition (safe)", function2);
 }
 
-criterion_group!(benches, compare_fibonaccis);
+criterion_group!(benches, bench_partition);
 criterion_main!(benches);

--- a/benches/partition.rs
+++ b/benches/partition.rs
@@ -1,0 +1,26 @@
+#[macro_use]
+extern crate criterion;
+extern crate rand;
+extern crate forester;
+
+use std::f64;
+
+use criterion::Criterion;
+use criterion::Bencher;
+
+use forester::array_ops::Partition;
+
+
+fn bench_partition(c: &mut Criterion) {
+    fn function(b: &mut Bencher) {
+        let mut x: Vec<_> = (1..1000).collect();
+        b.iter(|| {
+            x.clone().partition(|&i| i % 2 == 0);
+        })
+    }
+
+    c.bench_function("Partition", function);
+}
+
+criterion_group!(benches, compare_fibonaccis);
+criterion_main!(benches);


### PR DESCRIPTION
Managed a speed-up of about 50% in the partition function by using unsafe pointer arithmetic instead of safe slice indexing.