### PR TITLE
Custom built cargo-tarpaulin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ addons:
 
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+    cargo install cargo-tarpaulin
+    # bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
 
     # Uncomment the following line for coveralls.io
     # cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
+  
+after_script: |
+  if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+    cargo install cargo-tarpaulin
+  fi
 
 cache: cargo
 
@@ -27,7 +32,6 @@ addons:
 
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    cargo install cargo-tarpaulin
     # bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
 
     # Uncomment the following line for coveralls.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   
 before_script: |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-    cargo install cargo-tarpaulin
+    cargo install cargo-tarpaulin || true
   fi
 
 cache: cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     - rust: nightly
   fast_finish: true
   
-after_script: |
+before_script: |
   if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
     cargo install cargo-tarpaulin
   fi


### PR DESCRIPTION
The released binary of cargo-tarpaulin is incompatible with recent rust features.

This PR changes the CI system to build it with a recent toolchain (and caches the result).